### PR TITLE
Manual cache

### DIFF
--- a/android-exoplayer/build.gradle
+++ b/android-exoplayer/build.gradle
@@ -23,7 +23,7 @@ android {
 
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    implementation('com.google.android.exoplayer:exoplayer:2.10.5') {
+    api('com.google.android.exoplayer:exoplayer:2.10.5') {
         exclude group: 'com.android.support'
     }
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -43,7 +43,6 @@ import com.google.android.exoplayer2.source.BehindLiveWindowException;
 import com.google.android.exoplayer2.source.ExtractorMediaSource;	
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.MergingMediaSource;
-import com.google.android.exoplayer2.source.ProgressiveMediaSource;
 import com.google.android.exoplayer2.source.SingleSampleMediaSource;
 import com.google.android.exoplayer2.source.TrackGroup;
 import com.google.android.exoplayer2.source.TrackGroupArray;
@@ -62,7 +61,6 @@ import com.google.android.exoplayer2.upstream.BandwidthMeter;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultAllocator;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
-import com.google.android.exoplayer2.upstream.cache.Cache;
 import com.google.android.exoplayer2.upstream.cache.CacheDataSourceFactory;
 import com.google.android.exoplayer2.upstream.cache.SimpleCache;
 import com.google.android.exoplayer2.util.Util;
@@ -197,7 +195,7 @@ class ReactExoplayerView extends FrameLayout implements
     private void createViews() {
         clearResumePosition();
         mediaDataSourceFactory = buildDataSourceFactory(true);
-        downloadCache = ExoPlayerCache.getInstance(getContext());
+        downloadCache = VideoCache.getInstance().getSimpleCache();
 
         if (CookieHandler.getDefault() != DEFAULT_COOKIE_MANAGER) {
             CookieHandler.setDefault(DEFAULT_COOKIE_MANAGER);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoCache.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoCache.java
@@ -1,0 +1,37 @@
+package com.brentvatne.exoplayer;
+
+import com.google.android.exoplayer2.upstream.cache.SimpleCache;
+
+public class VideoCache {
+
+    private static volatile VideoCache instance;
+    private static SimpleCache cache;
+
+    private VideoCache() {
+        if (instance != null) {
+            throw new RuntimeException("Use getInstance()");
+        }
+    }
+
+    public void setSimpleCache(SimpleCache cache) {
+        this.cache = cache;
+    }
+
+    public SimpleCache getSimpleCache() {
+        if (this.cache == null) {
+            throw new RuntimeException("Tried to access video cache but no cache is set");
+        }
+
+        return this.cache;
+    }
+
+    public static VideoCache getInstance() {
+        if (instance == null) {
+            synchronized (VideoCache.class) {
+                if (instance == null) instance = new VideoCache();
+            }
+        }
+
+        return instance;
+    }
+}

--- a/ios/RCTVideo.m
+++ b/ios/RCTVideo.m
@@ -591,6 +591,7 @@ static int const RCTVideoUnset = -1;
                   didLoadData:(NSData *)data
                        forURL:(NSURL *)url {
     DebugLog(@"dvAssetLoaderDelegate: url '%@'", [url absoluteString]);
+    
     [_videoCache storeItem:data forUri:[url absoluteString] withCallback:^(BOOL success) {
         DebugLog(@"Cache data stored successfully 🎉");
     }];

--- a/ios/RCTVideoCache.h
+++ b/ios/RCTVideoCache.h
@@ -23,8 +23,6 @@ typedef NS_ENUM(NSUInteger, RCTVideoCacheStatus) {
 }
 
 @property(nonatomic, strong) SPTPersistentCache * _Nullable videoCache;
-@property(nonatomic, strong) NSString * cachePath;
-@property(nonatomic, strong) NSString * cacheIdentifier;
 @property(nonatomic, strong) NSString * temporaryCachePath;
 
 + (RCTVideoCache *)sharedInstance;
@@ -34,5 +32,6 @@ typedef NS_ENUM(NSUInteger, RCTVideoCacheStatus) {
 - (AVURLAsset *)getItemFromTemporaryStorage:(NSString *)key;
 - (BOOL)saveDataToTemporaryStorage:(NSData *)data key:(NSString *)key;
 - (void) createTemporaryPath;
+- (void) setVideoCache:(SPTPersistentCache *)videoCache;
 
 @end

--- a/ios/RCTVideoCache.m
+++ b/ios/RCTVideoCache.m
@@ -3,8 +3,6 @@
 @implementation RCTVideoCache
 
 @synthesize videoCache;
-@synthesize cachePath;
-@synthesize cacheIdentifier;
 @synthesize temporaryCachePath;
 
 + (RCTVideoCache *)sharedInstance {
@@ -18,24 +16,7 @@
 
 - (id)init {
   if (self = [super init]) {
-    self.cacheIdentifier = @"rct.video.cache";
-    self.temporaryCachePath = [NSTemporaryDirectory() stringByAppendingPathComponent:self.cacheIdentifier];
-    self.cachePath = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject stringByAppendingPathComponent:self.cacheIdentifier];
-    SPTPersistentCacheOptions *options = [SPTPersistentCacheOptions new];
-    options.cachePath = self.cachePath;
-    options.cacheIdentifier = self.cacheIdentifier;
-    options.defaultExpirationPeriod = 60 * 60 * 24 * 30;
-    options.garbageCollectionInterval = (NSUInteger)(1.5 * SPTPersistentCacheDefaultGCIntervalSec);
-    options.sizeConstraintBytes = 1024 * 1024 * 100;
-    options.useDirectorySeparation = NO;
-#ifdef DEBUG
-    options.debugOutput = ^(NSString *string) {
-      NSLog(@"Video Cache: %@", string);
-    };
-#endif
-    [self createTemporaryPath];
-    self.videoCache = [[SPTPersistentCache alloc] initWithOptions:options];
-    [self.videoCache scheduleGarbageCollector];
+    self.temporaryCachePath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"cache"];
   }
   return self;
 }
@@ -60,6 +41,8 @@
     handler(NO);
     return;
   }
+
+    
   [self saveDataToTemporaryStorage:data key:key];
   [self.videoCache storeData:data forKey:key locked:NO withCallback:^(SPTPersistentCacheResponse * _Nonnull response) {
     if (response.error) {


### PR DESCRIPTION
For both iOS and Android this allows setting the cache from outside of the package so we can configure the parameters in JS.

Android specific: the changes in ExoPlayerCache make sure we always export the full video. Previously the video cache would cache the video in 5 MB parts, the export code would download the full video again (and cache it in a full X MB file).

Now: The datasource first loads from the video player cache, if a part is missing or incomplete it will use the dataspec to download the missing bits. This should solve the export issue and significantly speed things up since it can now benefit from the video player cache while exporting!

Still needs a bit of cleanup :)
Mobileapp PR will follow tomorrow!