### PR TITLE
Reject promise on every exception in video export

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerCache.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerCache.java
@@ -5,7 +5,6 @@ import android.net.Uri;
 import android.util.Log;
 
 import com.google.android.exoplayer2.C;
-import com.google.android.exoplayer2.upstream.HttpDataSource;
 import com.google.android.exoplayer2.upstream.cache.NoOpCacheEvictor;
 import com.google.android.exoplayer2.upstream.cache.Cache;
 import com.google.android.exoplayer2.upstream.cache.SimpleCache;

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerCache.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerCache.java
@@ -42,7 +42,7 @@ public class ExoPlayerCache extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void exportVideo(final String url, boolean improvedErrorHandling, final Promise promise) {
+    public void exportVideo(final String url, final Promise promise) {
         Log.d(getName(), "exportVideo");
 
         Thread exportThread = new Thread(new Runnable() {
@@ -79,9 +79,7 @@ public class ExoPlayerCache extends ReactContextBaseJavaModule {
                         Log.d(getName(), "Read error");
                         e.printStackTrace();
 
-                        if (improvedErrorHandling) {
-                            throw e;
-                        }
+                        throw e;
                     }
 
                     CacheUtil.getCached(
@@ -98,11 +96,9 @@ public class ExoPlayerCache extends ReactContextBaseJavaModule {
                     Log.d(getName(), "Export error");
                     e.printStackTrace();
 
-                    if (improvedErrorHandling) {
-                        String className = e.getClass().getSimpleName();
-                        promise.reject(className, className + ": " + e.getMessage());
-                        return;
-                    }
+                    String className = e.getClass().getSimpleName();
+                    promise.reject(className, className + ": " + e.getMessage());
+                    return;
 
                     promise.reject(e);
                 }


### PR DESCRIPTION
Right now some exceptions are swallowed by `catch (IOException e) {}` and as result the promise is not rejected. We found a  relevant error (`class HttpDataSourceException extends IOException`, [source](https://github.com/google/ExoPlayer/blob/release-v2/library/common/src/main/java/com/google/android/exoplayer2/upstream/HttpDataSource.java#L232)) is thrown in the try block that indicate the file can't be read from the http source. That means the file is not downloaded, the promise is resolved and therefore the promise should be rejected.