### PR TITLE
Add different export video method

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerCache.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerCache.java
@@ -24,6 +24,7 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -91,7 +92,7 @@ public class ExoPlayerCache extends ReactContextBaseJavaModule {
                     );
 
                     if (!targetFile.exists()) {
-                        throw new Exception("Target file not present after writing bytes");
+                        throw new Exception("Target file bytes (" + bytesRead + ") not present after writing `" + targetFile.getPath() + "`");
                     }
 
                     Log.d(getName(), "Export succeeded");
@@ -103,6 +104,95 @@ public class ExoPlayerCache extends ReactContextBaseJavaModule {
                     result.putDouble("bytesWritten", targetFile.length());
 
                     promise.resolve(result);
+                } catch (Exception e) {
+                    Log.d(getName(), "Export error");
+                    e.printStackTrace();
+
+                    String className = e.getClass().getSimpleName();
+                    promise.reject(className, className + ": " + e.getMessage());
+                    return;
+                }
+            }
+        }, "export_thread");
+        exportThread.start();
+    }
+
+    @ReactMethod
+    public void exportVideoImproved(final String url, final Promise promise) {
+        Log.d(getName(), "exportVideoImproved");
+
+        Thread exportThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Log.d(getName(), "Exporting...");
+                Log.d(getName(), url);
+                final Uri uri = Uri.parse(url);
+                final DataSpec dataSpec = new DataSpec(uri, 0, C.LENGTH_UNSET, null);
+                final SimpleCache downloadCache = ExoPlayerCache.getInstance(getReactApplicationContext());
+                CacheKeyFactory cacheKeyFactory = ds -> CACHE_KEY_PREFIX + "." + CacheUtil.generateKey(ds.uri);;
+                BufferedOutputStream outStream = null;
+
+                try {
+                    try {
+                        CacheUtil.getCached(
+                            dataSpec,
+                            downloadCache,
+                            cacheKeyFactory
+                        );
+
+                        DataSourceInputStream inputStream = new DataSourceInputStream(createDataSource(downloadCache), dataSpec);
+                        File targetFile = new File(ExoPlayerCache.getCacheDir(getReactApplicationContext()) + "/" + uri.getLastPathSegment());
+
+                        // https://stackoverflow.com/questions/14378898/fileoutputstream-does-not-create-file
+                        outStream = new BufferedOutputStream(new FileOutputStream(targetFile));
+
+                        if (!targetFile.exists()) {
+                            boolean parentExists = targetFile.getParentFile() != null && targetFile.getParentFile().exists();
+                            boolean parentWritable = targetFile.getParentFile() != null && targetFile.getParentFile().canWrite();
+                            boolean targetWriteable = targetFile.canWrite();
+                            String parentLabel = "parent (" + (parentWritable ? "is writable" : "not writable") + ")";
+                            String targetLabel = "target (" + (targetWriteable ? "is writable" : "not writable") + ")";
+
+                            if (!parentExists) {
+                                throw new Exception(targetLabel + " and " + parentLabel + " not present after stream creation `" + targetFile.getPath() + "`");
+                            } else {
+                                throw new Exception(targetLabel + " not present in " + parentLabel + " after stream creation `" + targetFile.getPath() + "`");
+                            }
+                        }
+
+                        byte[] buffer = new byte[8 * 1024];
+                        int bytesRead;
+                        while ((bytesRead = inputStream.read(buffer)) != -1) {
+                            outStream.write(buffer, 0, bytesRead);
+                            // TODO Add onProgress() callback here
+                        }
+
+                        CacheUtil.getCached(
+                            dataSpec,
+                            downloadCache,
+                            cacheKeyFactory
+                        );
+
+                        if (!targetFile.exists()) {
+                            throw new Exception("Target file bytes (" + bytesRead + ") not present after writing `" + targetFile.getPath() + "`");
+                        }
+
+                        Log.d(getName(), "Export succeeded");
+                        Log.d(getName(), targetFile.getPath());
+
+                        WritableMap result =  Arguments.createMap();
+                        result.putString("path", targetFile.getPath());
+                        result.putDouble("bytesRead", inputStream.bytesRead());
+                        result.putDouble("bytesWritten", targetFile.length());
+
+                        promise.resolve(result);
+                    } finally {
+                        if (outStream != null) {
+                            // Flush streams and release system resources
+                            outStream.close();
+                        }
+                    }
+
                 } catch (Exception e) {
                     Log.d(getName(), "Export error");
                     e.printStackTrace();

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerCache.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerCache.java
@@ -167,17 +167,18 @@ public class ExoPlayerCache extends ReactContextBaseJavaModule {
                             // TODO Add onProgress() callback here
                         }
 
-                        CacheUtil.getCached(
-                                dataSpec,
-                                downloadCache,
-                                cacheKeyFactory
-                        );
                     } finally {
                         if (outStream != null) {
                             // Flush streams and release system resources
                             outStream.close();
                         }
                     }
+
+                    CacheUtil.getCached(
+                        dataSpec,
+                        downloadCache,
+                        cacheKeyFactory
+                    );
 
                     if (!targetFile.exists()) {
                         throw new Exception("Target file bytes (" + bytesRead + ") not present after writing `" + targetFile.getPath() + "`");


### PR DESCRIPTION
## What type of PR is this?
<!-- Check all applicable -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Experiment update

## Description
- Log file path in `exportVideo`
- Add new method `exportVideoImproved`
  - Close and flush streams once done
  - Use BufferedOutputStream (https://stackoverflow.com/a/14378992)
  - Throw error if `FileOutputStream` did not create a file before writing
  - If file was not created before writing, log details on file/parent permissions