### PR TITLE
Make exo player cache size and directory configurable

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerCache.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerCache.java
@@ -33,6 +33,7 @@ public class ExoPlayerCache extends ReactContextBaseJavaModule {
     private static SimpleCache instance = null;
     private static final String CACHE_KEY_PREFIX = "exoPlayerCacheKeyPrefix";
     private static long maxCacheSizeBytes = -1; // Default no maximum size
+    private static String cacheSubDirectory = "";
 
     public ExoPlayerCache(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -46,7 +47,13 @@ public class ExoPlayerCache extends ReactContextBaseJavaModule {
     @ReactMethod
     public void setMaxCacheSize(final int bytes, final Promise promise) {
         maxCacheSizeBytes = bytes;
-        promise.resolve(bytes);
+        promise.resolve(maxCacheSizeBytes);
+    }
+
+    @ReactMethod
+    public void setCacheSubDirectory(final String directory, final Promise promise) {
+        cacheSubDirectory = directory;
+        promise.resolve(cacheSubDirectory);
     }
 
     @ReactMethod
@@ -123,7 +130,7 @@ public class ExoPlayerCache extends ReactContextBaseJavaModule {
     public static SimpleCache getInstance(Context context) {
         if(instance == null) {
             instance = new SimpleCache(
-                new File(ExoPlayerCache.getCacheDir(context) + "/exo_player"),
+                new File(ExoPlayerCache.getCacheDir(context) + cacheSubDirectory),
                 maxCacheSizeBytes == -1
                     ? new NoOpCacheEvictor()
                     : new LeastRecentlyUsedCacheEvictor(maxCacheSizeBytes)

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerCache.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerCache.java
@@ -116,7 +116,7 @@ public class ExoPlayerCache extends ReactContextBaseJavaModule {
 
     public static SimpleCache getInstance(Context context) {
         if(instance == null) {
-            instance = new SimpleCache(new File(ExoPlayerCache.getCacheDir(context)), new NoOpCacheEvictor());
+            instance = new SimpleCache(new File(ExoPlayerCache.getCacheDir(context) + "/exo_player"), new NoOpCacheEvictor());
         }
         return instance;
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerCache.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerCache.java
@@ -7,7 +7,7 @@ import android.util.Log;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 import com.google.android.exoplayer2.C;
-import com.google.android.exoplayer2.upstream.cache.NoOpCacheEvictor;
+import com.google.android.exoplayer2.upstream.cache.LeastRecentlyUsedCacheEvictor;
 import com.google.android.exoplayer2.upstream.cache.Cache;
 import com.google.android.exoplayer2.upstream.cache.SimpleCache;
 import com.google.android.exoplayer2.upstream.cache.CacheUtil;
@@ -17,10 +17,8 @@ import com.google.android.exoplayer2.upstream.DataSpec;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DataSourceInputStream;
 
-import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 
@@ -33,6 +31,7 @@ public class ExoPlayerCache extends ReactContextBaseJavaModule {
 
     private static SimpleCache instance = null;
     private static final String CACHE_KEY_PREFIX = "exoPlayerCacheKeyPrefix";
+    private static final long MAX_CACHE_SIZE_BYTES = 400 * (1024 * 1024); // => 400 MB
 
     public ExoPlayerCache(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -116,7 +115,10 @@ public class ExoPlayerCache extends ReactContextBaseJavaModule {
 
     public static SimpleCache getInstance(Context context) {
         if(instance == null) {
-            instance = new SimpleCache(new File(ExoPlayerCache.getCacheDir(context) + "/exo_player"), new NoOpCacheEvictor());
+            instance = new SimpleCache(
+                new File(ExoPlayerCache.getCacheDir(context) + "/exo_player"),
+                new LeastRecentlyUsedCacheEvictor(MAX_CACHE_SIZE_BYTES)
+            );
         }
         return instance;
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerCache.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerCache.java
@@ -31,7 +31,7 @@ public class ExoPlayerCache extends ReactContextBaseJavaModule {
 
     private static SimpleCache instance = null;
     private static final String CACHE_KEY_PREFIX = "exoPlayerCacheKeyPrefix";
-    private static final long MAX_CACHE_SIZE_BYTES = 400 * (1024 * 1024); // => 400 MB
+    private static final long MAX_CACHE_SIZE_BYTES = 380 * (1024 * 1024); // => 380 MB
 
     public ExoPlayerCache(ReactApplicationContext reactContext) {
         super(reactContext);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerCache.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerCache.java
@@ -32,7 +32,7 @@ public class ExoPlayerCache extends ReactContextBaseJavaModule {
 
     private static SimpleCache instance = null;
     private static final String CACHE_KEY_PREFIX = "exoPlayerCacheKeyPrefix";
-    private static long maxCacheSizeBytes = -1; // Default no maximum size
+    private static int maxCacheSizeBytes = -1; // Default no maximum size
     private static String cacheSubDirectory = "";
 
     public ExoPlayerCache(ReactApplicationContext reactContext) {


### PR DESCRIPTION
## What type of PR is this?
<!-- Check all applicable -->
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Experiment update

## Description
Add two static React Methods which allow you to configure the:
- `setMaxCacheSize`: maximum allowed cache size by using exo player's `LeastRecentlyUsedCacheEvictor`
- `setCacheSubDirectory`: sub directory where the cache register of the exo player is written to
